### PR TITLE
Always request current variable values when stack position changes (fixes #10)

### DIFF
--- a/src/Components/DebugContainer/CallStackContainer/CallStackContainer.js
+++ b/src/Components/DebugContainer/CallStackContainer/CallStackContainer.js
@@ -1,8 +1,6 @@
 import React, {useContext, useEffect, useState} from "react";
 
 import StackContext from "../../../Providers/StackContext";
-import WorkerContext from "../../../Providers/WorkerContext";
-import CDL_WORKER_PROTOCOL from "../../../Services/CDL_WORKER_PROTOCOL";
 import {CallStackRow} from "./CallStackRow/CallStackRow";
 
 import "./CallStackContainer.scss";
@@ -15,7 +13,6 @@ export function CallStackContainer () {
     const [callStack, setCallStack] = useState();
 
     const {stack} = useContext(StackContext);
-    const {cdlWorker} = useContext(WorkerContext);
 
     useEffect(() => {
         if (stack) {
@@ -32,15 +29,6 @@ export function CallStackContainer () {
                 calls.push(row);
             });
             setCallStack(calls);
-
-            if (cdlWorker) {
-                cdlWorker.current.postMessage({
-                    code: CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK,
-                    args: {
-                        position: stack[0].position,
-                    },
-                });
-            }
         }
     }, [stack]);
 

--- a/src/Components/DebugContainer/CallStackContainer/CallStackRow/CallStackRow.js
+++ b/src/Components/DebugContainer/CallStackContainer/CallStackRow/CallStackRow.js
@@ -27,7 +27,6 @@ CallStackRow.propTypes = {
  * @return {JSX}
  */
 export function CallStackRow ({index, functionName, fileName, lineno, position}) {
-    const {cdlWorker} = useContext(WorkerContext);
     const {stackPosition, setStackPosition} = useContext(StackPositionContext);
     const {stack} = useContext(StackContext);
     const {setActiveFile} = useContext(ActiveFileContext);
@@ -40,14 +39,6 @@ export function CallStackRow ({index, functionName, fileName, lineno, position})
      * @param {Event} e
      */
     const selectStackPosition = (e) => {
-        if (cdlWorker) {
-            cdlWorker.current.postMessage({
-                code: CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK,
-                args: {
-                    position: position,
-                },
-            });
-        }
         setActiveFile(stack[index].fileName);
         setStackPosition(index);
     };

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -41,13 +41,15 @@ function CDLProviders ({children, fileInfo}) {
 
     // Get new variable stack if stack position changes
     useEffect(() => {
-        if (cdlWorker && stackPosition !== undefined) {
+        if (cdlWorker?.current && stackPosition !== undefined && stack?.[stackPosition]) {
             cdlWorker.current.postMessage({
                 code: CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK,
                 args: {
                     position: stack[stackPosition].position,
                 },
             });
+        } else {
+            console.warn('Invalid stack position or stack not initialized');
         }
     }, [stackPosition, stack]);
 

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -39,6 +39,18 @@ function CDLProviders ({children, fileInfo}) {
         };
     }, []);
 
+    // Get new variable stack if stack position changes
+    useEffect(() => {
+        if (cdlWorker && stackPosition !== undefined) {
+            cdlWorker.current.postMessage({
+                code: CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK,
+                args: {
+                    position: stack[stackPosition].position,
+                },
+            });
+        }
+    }, [stackPosition, stack]);
+
     // Create worker to handle file.
     useEffect(() => {
         if (fileInfo) {


### PR DESCRIPTION
Watch for changes in stack/stack position and request variables for ew position; Remove unnecessary messages to workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed `cdlWorker` context usage from `CallStackContainer` and `CallStackRow` components.
	- Added new `useEffect` hook in `CDLProviders` to manage variable stack retrieval based on stack position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->