### PR TITLE
When scanning for variable values at a given position, use the latest variable value (fixes #12).

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -133,10 +133,12 @@ class CdlLog {
 
             if (childLtInfo.getfId() === parentId) {
                 childLtInfo.getVariables().forEach((variable, index) => {
-                    try {
-                        variableStack[variable] = JSON5.parse(this.variables[position][index]);
-                    } catch (e) {
-                        variableStack[variable] = this.variables[position][index];
+                    if (!(variable in variableStack)) {
+                        try {
+                            variableStack[variable] = JSON5.parse(this.variables[position][index]);
+                        } catch (e) {
+                            variableStack[variable] = this.variables[position][index];
+                        }
                     }
                 });
             }


### PR DESCRIPTION
As the title says, when scanning for variable values in a function, the program currently saves the first value of the variable encountered in the function. This is because it scans backwards from the given position to the function definition, this PR adds a check to make sure a variable isn't updated if it already has the latest value.