### PR TITLE
Improve and refactor logic when adding to call stack while processing execution log (fixes #14).

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -196,11 +196,11 @@ class CdlLog {
             this.callStack.push(position);
         }
 
+        const childId = currlt.getId();
         while (this.callStack.length >= 1) {
-            const stackTop = this.callStack[this.callStack.length - 1];
-            const stackLt = this.getLogTypeInfoAtPosition(stackTop);
-            const childId = currlt.getId();
-            if (stackLt.containsChild(childId)) {
+            const stackTopPosition = this.callStack[this.callStack.length - 1];
+            const stackTopLt = this.getLogTypeInfoAtPosition(stackTopPosition);
+            if (stackTopLt.containsChild(childId)) {
                 break;
             } else {
                 this.callStack.pop();

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -196,12 +196,14 @@ class CdlLog {
             this.callStack.push(position);
         }
 
-        const cs = this.callStack;
-        if (cs.length > 0) {
-            let lt = this.getLogTypeInfoAtPosition(cs[cs.length - 1]);
-            while (!lt.containsChild(currlt.getId()) ) {
-                cs.pop();
-                lt = this.getLogTypeInfoAtPosition(cs[cs.length - 1]);
+        while (this.callStack.length >= 1) {
+            const stackTop = this.callStack[this.callStack.length - 1];
+            const stackLt = this.getLogTypeInfoAtPosition(stackTop);
+            const childId = currlt.getId();
+            if (stackLt.containsChild(childId)) {
+                break;
+            } else {
+                this.callStack.pop();
             }
         }
 


### PR DESCRIPTION
This PR addresses an issue with the logic while extracting the call stack, more specifically, it fails to check if the call stack size is greater than zero while moving down the stack. This results in an attempt to check if an undefined log type contains a child element resulting in an error. This PR refactors the logic to fix the error and improves readability. 

Note: While addressing this issue, I realized that I need to add better guards to check for invalid values to make the code more robust. This will be addressed in the coming PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved internal processing logic for execution logging.
	- Simplified stack management and index calculation in log processing method.

Note: These changes are primarily internal improvements that do not directly impact end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->