### PR TITLE
Use file path for tab name if there are multiple files with the same name.

### DIFF
--- a/src/Components/Tabs/Tab/Tab.js
+++ b/src/Components/Tabs/Tab/Tab.js
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useRef, useState} from "react";
+import React, {useContext, useEffect, useRef} from "react";
 
 import PropTypes from "prop-types";
 import {FiletypePy} from "react-bootstrap-icons";
@@ -9,14 +9,14 @@ import "./Tab.scss";
 
 Tab.propTypes = {
     filePath: PropTypes.string,
-    fileName: PropTypes.string,
+    tabName: PropTypes.string,
 };
 
 /**
  * Renders a Tab.
  * @return {JSX.Element}
  */
-export function Tab ({filePath, fileName}) {
+export function Tab ({filePath, tabName}) {
     const tabRef = useRef();
     const {activeFile, setActiveFile} = useContext(ActiveFileContext);
 
@@ -40,7 +40,7 @@ export function Tab ({filePath, fileName}) {
 
     return (
         <div ref={tabRef} className="tab d-flex align-items-center" onClick={selectFile}>
-            <FiletypePy className="icon"/> {fileName}
+            <FiletypePy className="icon"/> {tabName}
         </div>
     );
 }

--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -26,8 +26,10 @@ export function Tabs ({}) {
             // If fileName occurs more than once, then use filepath as tabName.
             const tabsJSX = Object.keys(fileTree).map((filePath, index) => {
                 const count = getFrequencyOfItem(fileNames, fileNames[index]);
-                const tabName = (count === 1)?fileNames[index]:filePath;
-                return <Tab key={index} filePath={filePath} tabName={tabName}></Tab>;
+                const tabName = count === 1
+                    ? fileNames[index]
+                    : filePath;
+                return <Tab key={filePath} filePath={filePath} tabName={tabName}></Tab>;
             });
             setTabs(tabsJSX);
         }

--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -14,18 +14,18 @@ export function Tabs ({}) {
 
     const [tabs, setTabs] = useState();
 
-    const getFrequency = (arr, item) => {
+    const getFrequencyOfItem = (arr, item) => {
         return arr.filter((x) => x === item).length;
     };
 
     useEffect(() => {
         if (fileTree) {
-            const filePaths = Object.keys(fileTree);
-            const fileNames = filePaths.map((path, index) => {
+            const fileNames = Object.keys(fileTree).map((path, index) => {
                 return path.split("/").pop();
             });
-            const tabsJSX = filePaths.map((filePath, index) => {
-                const count = getFrequency(fileNames, fileNames[index]);
+            // If fileName occurs more than once, then use filepath as tabName.
+            const tabsJSX = Object.keys(fileTree).map((filePath, index) => {
+                const count = getFrequencyOfItem(fileNames, fileNames[index]);
                 const tabName = (count === 1)?fileNames[index]:filePath;
                 return <Tab key={index} filePath={filePath} tabName={tabName}></Tab>;
             });

--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -14,11 +14,20 @@ export function Tabs ({}) {
 
     const [tabs, setTabs] = useState();
 
+    const getFrequency = (arr, item) => {
+        return arr.filter((x) => x === item).length;
+    };
+
     useEffect(() => {
         if (fileTree) {
-            const tabsJSX = Object.keys(fileTree).map((filePath, index) => {
-                const fileName = filePath.split("/").pop();
-                return <Tab key={index} filePath={filePath} fileName={fileName}></Tab>;
+            const filePaths = Object.keys(fileTree);
+            const fileNames = filePaths.map((path, index) => {
+                return path.split("/").pop();
+            });
+            const tabsJSX = filePaths.map((filePath, index) => {
+                const count = getFrequency(fileNames, fileNames[index]);
+                const tabName = (count === 1)?fileNames[index]:filePath;
+                return <Tab key={index} filePath={filePath} tabName={tabName}></Tab>;
             });
             setTabs(tabsJSX);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tab naming logic to handle duplicate file names more effectively.
	- Improved tab display by using full file path when multiple files share the same name.

- **Refactor**
	- Updated property names from `fileName` to `tabName` in Tab component.
	- Introduced frequency-checking mechanism for tab name generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->