### PR TITLE
Add feature to update key value in variable object when new variable value is logged.

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -128,13 +128,10 @@ class CdlLog {
         let newKey;
         if (key.type === "variable") {
             newKey = existingStack[key.value];
-            newStack[newKey] = {};
         } else if (key.type === "temp_variable") {
             newKey = existingTempStack[key.value];
-            newStack[newKey] = {};
         } else {
             newKey = key.value;
-            newStack[newKey] = {};
         }
 
         this._updateVariable(

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -113,8 +113,9 @@ class CdlLog {
         if (variable.keys.length == 0) {
             varStack[variable.name] = value;
         } else {
--            const currVal = Object.assign({}, varStack[variable.name]);
-+            const currVal = variable.name in varStack ? Object.assign({}, varStack[variable.name]) : {};
+            const currVal = variable.name in varStack ?
+                Object.assign({}, varStack[variable.name]) : {};
+
             let temp = currVal;
             for (let i = 0; i < variable.keys.length; i++) {
                 const key = variable.keys[i];

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -127,7 +127,6 @@ class CdlLog {
             } else {
                 newStack[key.value] = value;
             }
-            newStack[key.value] = {};
         }
         this._updateVariable(keys, newStack[key.value], value, existingStack);
 

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -112,7 +112,7 @@ class CdlLog {
      */
     _updateVariable (keys, newStack, value, existingStack) {
         if (keys.length === 1) {
-            if (keys[0].type === "variable") {
+            if (keys[0].type === "variable" || keys[0].type === "temp_variable") {
                 newStack[existingStack[keys[0].value]] = value;
             } else {
                 newStack[keys[0].value] = value;
@@ -121,12 +121,10 @@ class CdlLog {
         }
 
         const key = keys.shift();
-        if (!(key in newStack)) {
-            if (key.type === "variable") {
-                newStack[existingStack[key.value]] = value;
-            } else {
-                newStack[key.value] = value;
-            }
+        if (key.type === "variable" || key.type === "temp_variable") {
+            newStack[existingStack[key.value]] = value;
+        } else {
+            newStack[key.value] = value;
         }
         this._updateVariable(keys, newStack[key.value], value, existingStack);
 
@@ -163,7 +161,7 @@ class CdlLog {
                         globalVariables[variable.name] = currVal;
                     }
                 } else if (varFuncId === funcId) {
-                    // Local Vriables
+                    // Local Variables
                     if (variable.keys.length == 0) {
                         localVariables[variable.name] = currLog.value;
                     } else {

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -137,13 +137,8 @@ class CdlLog {
                         case "object":
                             temp[newKey] = Object.assign({}, value);
                             break;
-                        case "string":
-                            temp[newKey] = value.valueOf();
-                            break;
-                        case "string":
-                            temp[newKey] = value.valueOf();
-                            break;
                         default:
+                            temp[newKey] = value.valueOf();
                             break;
                     }
                 } else {

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -113,8 +113,8 @@ class CdlLog {
         if (variable.keys.length == 0) {
             varStack[variable.name] = value;
         } else {
-            const currVal = Object.assign({}, varStack[variable.name]);
-
+-            const currVal = Object.assign({}, varStack[variable.name]);
++            const currVal = variable.name in varStack ? Object.assign({}, varStack[variable.name]) : {};
             let temp = currVal;
             for (let i = 0; i < variable.keys.length; i++) {
                 const key = variable.keys[i];

--- a/src/Services/cdl/LtInfo.js
+++ b/src/Services/cdl/LtInfo.js
@@ -10,8 +10,10 @@ class LtInfo {
      * @param {String} filePath File this logtype belongs to.
      */
     constructor (ltInfo, filePath) {
-        for (var key in ltInfo) {
-            this[key] = ltInfo[key];
+        for (const key in ltInfo) {
+            if (key) {
+                this[key] = ltInfo[key];
+            }
         }
         this.filePath = filePath;
         this.fileName = filePath.split("/").pop();
@@ -21,7 +23,7 @@ class LtInfo {
      * Indicates if the current logtype is a function definition
      * @return {Boolean}
      */
-    isFunction() {
+    isFunction () {
         return this.type === "function";
     }
 

--- a/src/Services/cdl/VarInfo.js
+++ b/src/Services/cdl/VarInfo.js
@@ -8,21 +8,12 @@ class VarInfo {
      * @param {Object} varInfo Variable info.
      * @param {Number} logType Logtype this variable belogns to.
      */
-    constructor(varInfo, logType) {
-        if (!varInfo || typeof varInfo !== 'object') {
-            throw new Error('varInfo must be a non-null object');
-        }
-        if (logType === undefined || logType === null) {
-            throw new Error('logType is required');
-        }
-        
+    constructor (varInfo) {
         for (const key in varInfo) {
             if (Object.prototype.hasOwnProperty.call(varInfo, key)) {
                 this[key] = varInfo[key];
             }
         }
-        
-        this.logType = Number(logType);
     }
 
     /**
@@ -38,7 +29,7 @@ class VarInfo {
      * @return {Boolean}
      */
     isGlobal () {
-        return "global" in this && this.global === true
+        return "global" in this && this.global === true;
     }
 };
 


### PR DESCRIPTION
This PR modifies the diagnostic log viewer to support the decoupling of Log Types and Variables by the ADLI tool. It also improves the way that variables are updated so that it updates the specific key value pair. This improves the user experience significantly and allows for a more accurate representation of the variable values. 

For example:
```
var_name["key1"]["key2"] = 3

# name: var_name
# keys: ["key1", "key2"]
```

## Validation Performed

The zip file below contains three CDL files which were used to validate this code. 

- test.clp.zst contains a series of unusual variable assign statements to test the robustness of the key value extraction. 
- adli.clp.zst, if the variable value of file tree is inspected, it can be seen that the file name is used to properly update the variable. 
- compress.clp.zst was used to verify that exceptions can be successfully captured. 

[ValidationFiles.zip](https://github.com/user-attachments/files/19112311/ValidationFiles.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the system’s variable management for more consistent and reliable handling of settings across different contexts, leading to improved stability and predictability in how changes are reflected at runtime.
  - Streamlined error handling and control flow in the header parsing process for better clarity.
  - Improved scoping and conditional checks in the constructor of the `LtInfo` class.
  - Simplified the constructor of the `VarInfo` class by reducing parameters.
  - Minor formatting adjustments throughout the code for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->