### PR TITLE
Track instances of variables using unique variable instance id to maintain accurate variable values (and eliminate unnecessary logging).

### DIFF
--- a/src/Services/cdl/CDL_CONSTANTS.js
+++ b/src/Services/cdl/CDL_CONSTANTS.js
@@ -9,6 +9,7 @@ const LINE_TYPE_DELIMITER = {
     "VARIABLE": "#",
     "EXCEPTION": "?",
     "IR_HEADER": "{",
+    "VAR_UNIQUE_ID": "@",
 };
 
 export {LINE_TYPE, LINE_TYPE_DELIMITER};

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -134,13 +134,13 @@ class CdlLog {
                 }
 
                 if (i === variable.keys.length - 1) {
-                    switch (typeof value) {
-                        case "object":
-                            temp[newKey] = Object.assign({}, value);
-                            break;
-                        default:
-                            temp[newKey] = value.valueOf();
-                            break;
+                    if (Array.isArray(value)) {
+                        temp[newKey] = [...value];
+                    } else if (value !== null && typeof value == "object") {
+                        temp[newKey] = Object.assign({}, value);
+                    } else {
+                        temp[newKey] = value === null || value === undefined ?
+                            value : value.valueOf();
                     }
                 } else {
                     temp = temp[newKey];

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -38,10 +38,11 @@ class CdlLogLine {
      */
     _processVariable (log) {
         this.type = LINE_TYPE.VARIABLE;
-        const pattern = /^# ([0-9]+) (.*$)/gm;
+        const pattern = /^# ([0-9]+) ([0-9]+) (.*$)/gm;
         const parsedInfo = pattern.exec(log);
-        this.value = this._parseVariableIfJSON(parsedInfo[2]);
         this.varid = parseInt(parsedInfo[1]);
+        this.uniqueid = this._parseVariableIfJSON(parsedInfo[2]);
+        this.value = this._parseVariableIfJSON(parsedInfo[3]);
     }
 
     /**

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -24,6 +24,8 @@ class CdlLogLine {
             case LINE_TYPE_DELIMITER.IR_HEADER:
                 this._processIRHeader(log);
                 break;
+            case LINE_TYPE_DELIMITER.VAR_UNIQUE_ID:
+                break;
             default:
                 this.type = LINE_TYPE.EXECUTION;
                 this.lt = parseInt(log);

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -11,8 +11,8 @@ class CdlLogLine {
      * @param {Array} logLine The contents of a single log line.
      */
     constructor (logLine) {
-        const pattern  = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
-        const log = pattern.exec(logLine[0])[1]
+        const pattern = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
+        const log = pattern.exec(logLine[0])[1];
 
         switch (log.charAt(0)) {
             case LINE_TYPE_DELIMITER.VARIABLE:


### PR DESCRIPTION
This PR has been placed on hold. This optimization isn't necessary, for now, only a unique id for the self variables is added. See PR #35.

--------------------------------------------------------

This PR uses the unique var_instance_id logged by the ADLI tool for each variable to keep track of variables which are updated across multiple functions. 

This addresses issue #29.

Note: I am still exploring this and the way I approach this problem will change with time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced log processing to extract an additional numeric detail, resulting in a unique identifier alongside existing log values for improved clarity and consistency.
  - Improved handling of array and null values during log updates, ensuring more robust data processing.
  - Introduced a new delimiter type for log processing.
- **Refactor**
  - Updated method parameter naming for clarity in the `getVariablesAtPosition` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->