### PR TITLE
Fix: Check if value is an array before copying and assigning value into nested object (fixes #31).

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -136,10 +136,11 @@ class CdlLog {
                 if (i === variable.keys.length - 1) {
                     if (Array.isArray(value)) {
                         temp[newKey] = [...value];
-                    } else if (typeof value == "object") {
+                    } else if (value !== null && typeof value == "object") {
                         temp[newKey] = Object.assign({}, value);
                     } else {
-                        temp[newKey] = value.valueOf();
+                        temp[newKey] = value === null || value === undefined ?
+                            value : value.valueOf();
                     }
                 } else {
                     temp = temp[newKey];


### PR DESCRIPTION
In PR #28, logic was implemented to copy values into nested objects. However, in the logic, it is unable to differentiate between arrays and objects. This results in an array value being transformed into an object because Object.assign is used to copy the value.

This PR adds a check to see if the value is an array and copies the array into the nested key value using the spread operator instead of treating it as an object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal processing of data assignments to enhance clarity.
  - Ensured consistent handling of arrays and objects without affecting visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->