### PR TITLE
Add feature to identify every instance of an object uniquely.

### DIFF
--- a/src/Services/cdl/CDL_CONSTANTS.js
+++ b/src/Services/cdl/CDL_CONSTANTS.js
@@ -3,12 +3,14 @@ const LINE_TYPE = {
     "EXCEPTION": 2,
     "EXECUTION": 3,
     "IR_HEADER": 4,
+    "UID": 5,
 };
 
 const LINE_TYPE_DELIMITER = {
     "VARIABLE": "#",
     "EXCEPTION": "?",
     "IR_HEADER": "{",
+    "SELF_UID": "@",
 };
 
 export {LINE_TYPE, LINE_TYPE_DELIMITER};

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -48,6 +48,9 @@ class CdlLog {
                 case LINE_TYPE.EXCEPTION:
                     this.exception = currLog.value;
                     break;
+                case LINE_TYPE.UID:
+                    this.uid = currLog.uid;
+                    break;
                 default:
                     break;
             }

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -11,8 +11,8 @@ class CdlLogLine {
      * @param {Array} logLine The contents of a single log line.
      */
     constructor (logLine) {
-        const pattern  = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
-        const log = pattern.exec(logLine[0])[1]
+        const pattern = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
+        const log = pattern.exec(logLine[0])[1];
 
         switch (log.charAt(0)) {
             case LINE_TYPE_DELIMITER.VARIABLE:
@@ -23,6 +23,9 @@ class CdlLogLine {
                 break;
             case LINE_TYPE_DELIMITER.IR_HEADER:
                 this._processIRHeader(log);
+                break;
+            case LINE_TYPE_DELIMITER.SELF_UID:
+                this._processUid(log);
                 break;
             default:
                 this.type = LINE_TYPE.EXECUTION;
@@ -52,6 +55,15 @@ class CdlLogLine {
     _processExeception (log) {
         this.type = LINE_TYPE.EXCEPTION;
         this.value = log.slice(2);
+    }
+
+    /**
+     * Extracts the UID from the log line.
+     * @param {String} log
+     */
+    _processUid (log) {
+        this.type = LINE_TYPE.UID;
+        this.uid = log.slice(2);
     }
 
     /**


### PR DESCRIPTION
This PR adds functionality to uniquely identify every instance of an object that was created. It does the following:

- Reads the unique id that was logged at the start of every function. 
- Saves the unique id to the global list of "self" variables (where key is UID and value is the variable value).
- When the variable stack is extracted, the existing variable value is loaded into the stack. 
- After extracting the variables, it then saves the updated value of the variable back into the global list.

By doing this, the value of **self** will be accurately represented. 

What is an example of a place where the value of self would not be accurately represented without this fix?
- Let's say that we are in a member function of a class called functionA. 
- From functionA we call functionB which is also a member function of the class and it updates the value of self. 
- When we return to funtionA, we would not have the latest value of self because it was updated in functionB.
- With this fix, we would have an accurate representation of self because the uniqueid of self would be the same in functionA and functionB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced log processing by capturing unique identifiers in log entries to improve traceability and debugging.
	- Introduced a new log type with a dedicated delimiter for handling unique identifier details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->