### PR TITLE
Add support for parsing unique id trace begin and end from CDL file. 

### DIFF
--- a/src/Services/cdl/CDL_CONSTANTS.js
+++ b/src/Services/cdl/CDL_CONSTANTS.js
@@ -3,12 +3,14 @@ const LINE_TYPE = {
     "EXCEPTION": 2,
     "EXECUTION": 3,
     "IR_HEADER": 4,
+    "UNIQUE_ID": 5,
 };
 
 const LINE_TYPE_DELIMITER = {
     "VARIABLE": "#",
     "EXCEPTION": "?",
     "IR_HEADER": "{",
+    "UNIQUE_ID": "@",
 };
 
 export {LINE_TYPE, LINE_TYPE_DELIMITER};

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -18,6 +18,7 @@ class CdlLog {
         this.callStacks = {};
         this.callStack = [];
         this.globalVariables = {};
+        this.uniqueids = [];
 
         this._processLog(logFile);
 
@@ -47,6 +48,13 @@ class CdlLog {
                     break;
                 case LINE_TYPE.EXCEPTION:
                     this.exception = currLog.value;
+                    break;
+                case LINE_TYPE.UNIQUE_ID:
+                    this.uniqueids.push({
+                        traceEvent: currLog.traceEvent,
+                        uid: currLog.uid,
+                        position: position,
+                    });
                     break;
                 default:
                     break;

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -11,8 +11,8 @@ class CdlLogLine {
      * @param {Array} logLine The contents of a single log line.
      */
     constructor (logLine) {
-        const pattern = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
-        const log = pattern.exec(logLine[0])[1];
+        const pattern = /^[.:a-zA-Z0-9_.-]+ (INFO|ERROR)+ adli (.*$)/sgm;
+        const log = pattern.exec(logLine[0])[2];
 
         switch (log.charAt(0)) {
             case LINE_TYPE_DELIMITER.VARIABLE:

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -66,7 +66,9 @@ class CdlLogLine {
      */
     _processUniqueId (log) {
         this.type = LINE_TYPE.UNIQUE_ID;
-        this.value = log;
+        const info = log.split(" ");
+        this.traceEvent = info[1];
+        this.uid = this._parseVariableIfJSON(info[2].trim());
     }
 
     /**

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -11,8 +11,8 @@ class CdlLogLine {
      * @param {Array} logLine The contents of a single log line.
      */
     constructor (logLine) {
-        const pattern  = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
-        const log = pattern.exec(logLine[0])[1]
+        const pattern = /^[.:a-zA-Z0-9_.-]+ [INFO|ERROR]+ adli (.*$)/sgm;
+        const log = pattern.exec(logLine[0])[1];
 
         switch (log.charAt(0)) {
             case LINE_TYPE_DELIMITER.VARIABLE:
@@ -23,6 +23,9 @@ class CdlLogLine {
                 break;
             case LINE_TYPE_DELIMITER.IR_HEADER:
                 this._processIRHeader(log);
+                break;
+            case LINE_TYPE_DELIMITER.UNIQUE_ID:
+                this._processUniqueId(log);
                 break;
             default:
                 this.type = LINE_TYPE.EXECUTION;
@@ -55,6 +58,18 @@ class CdlLogLine {
     }
 
     /**
+     * Extract metadata from uniqueid log line.
+     * Unique Id:
+     * "@ start <variable_name>"
+     * "@ end <variable_name>"
+     * @param {String} log
+     */
+    _processUniqueId (log) {
+        this.type = LINE_TYPE.UNIQUE_ID;
+        this.value = log;
+    }
+
+    /**
      * Extract metadata from header log line.
      * @param {String} log
      */
@@ -65,9 +80,11 @@ class CdlLogLine {
 
     /**
      * Parses the variable value if it is a JSON string.
+     * @param {Object} variable
+     * @return {Object}
      */
     _parseVariableIfJSON (variable) {
-        try{
+        try {
             return JSON5.parse(variable);
         } catch (exception) {
             return variable;


### PR DESCRIPTION
[PR #38](https://github.com/vishalpalaniappan/asp-adli-python/pull/38) in the ADLI tool adds support for logging the start and end of unique traces using the unique id. 

It does this by converting comments into logging statements.
```
def jobHandler (jobInfo):
    '''adli-trace-id-start jobInfo['uid']'''
    runJob(jobInfo)
    '''adli-trace-id-end jobInfo['uid']'''

# becomes

def jobHandler (jobInfo):
    logger.info(f"@ start {jobInfo["uid"]})
    runJob(jobInfo)
    logger.info(f"@ end {jobInfo["uid"]})
```

This PR adds support for the diagnostic log viewer to log the start and end of a unique trace so that it can successfully parse and open the diagnostic log file. The unique traces are saved in the uniqueid list in the CdlLog class.

Future PRs will visualize this information in the UI.

## Validation Performed

The PR was validated using the following files:

adli.clp.zst: A unique trace id was added to the program for each file that was processed. The program was executed and the log file that was generated was opened in the diagnostic log viewer to verify that the trace start and end position was captured.

compress.clp.zst: This file was generated by injecting logs into [this ](https://github.com/vancanhuit/simple-data-compression)interesting repo. A unique trace id was added to the program before and after the data was compressed. The program was executed and the log file that was generated was opened in the diagnostic log viewer to verify that the trace start and end position was captured.

[validation_files.zip](https://github.com/user-attachments/files/19330540/validation_files.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging capabilities now recognize and process unique identifier entries marked by special start/end indicators.
  - System definitions have been updated to include a new log entry type, improving the overall consistency and clarity in log processing.
  - New constants for unique IDs have been introduced, expanding the structure of log types and delimiters.
  - A new property for capturing unique identifiers associated with trace events has been added to the logging functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->