### PR TITLE
Add unique id logs to execution array (fixes #38). (#39)

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -18,7 +18,7 @@ class CdlLog {
         this.callStacks = {};
         this.callStack = [];
         this.globalVariables = {};
-        this.uniqueids = [];
+        this.traceEvents = [];
 
         this._processLog(logFile);
 
@@ -51,16 +51,26 @@ class CdlLog {
                     break;
                 case LINE_TYPE.UNIQUE_ID:
                     this.execution.push(currLog);
-                    this.uniqueids.push({
-                        traceEvent: currLog.traceEvent,
-                        uid: currLog.uid,
-                        position: position,
-                    });
+                    this._addToUniqueIds(currLog, position);
                     break;
                 default:
                     break;
             }
         } while (++position < logFile.length);
+    }
+
+    /**
+     * This function adds the given trace event to the global
+     * collection of trace events.
+     * @param {Object} currLog
+     * @param {Number} position
+     */
+    _addToUniqueIds (currLog, position) {
+        this.traceEvents.push({
+            traceEvent: currLog.traceEvent,
+            uid: currLog.uid,
+            position: position,
+        });
     }
 
 

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -50,6 +50,7 @@ class CdlLog {
                     this.exception = currLog.value;
                     break;
                 case LINE_TYPE.UNIQUE_ID:
+                    this.execution.push(currLog);
                     this.uniqueids.push({
                         traceEvent: currLog.traceEvent,
                         uid: currLog.uid,


### PR DESCRIPTION
This PR updates the code to add unique id logs to the programs execution array. While the unique ids are saved to a unique id object, the position doesn't accurately reflect the start/end of the trace in the execution array. 

By inserting the trace events into the execution array, the position will be accurate. This will allow us to extract the unique trace using the metadata in the unique traces object from the execution array.

This PR fixes #38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced log processing to capture all relevant details for unique identifier entries, resulting in more comprehensive execution records.
- **New Features**
	- Improved organization of log data with the introduction of a new method for handling unique ID logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->