### PR TITLE
Add feature to parse inputs and outputs from CDL log.

### DIFF
--- a/src/Services/cdl/CDL_CONSTANTS.js
+++ b/src/Services/cdl/CDL_CONSTANTS.js
@@ -2,14 +2,13 @@ const LINE_TYPE = {
     "VARIABLE": 1,
     "EXCEPTION": 2,
     "EXECUTION": 3,
-    "IR_HEADER": 4,
-    "UNIQUE_ID": 5,
+    "JSON": 4,
 };
 
 const LINE_TYPE_DELIMITER = {
     "VARIABLE": "#",
     "EXCEPTION": "?",
-    "IR_HEADER": "{",
+    "JSON": "{",
     "UNIQUE_ID": "@",
 };
 

--- a/src/Services/cdl/CdlHeader.js
+++ b/src/Services/cdl/CdlHeader.js
@@ -16,7 +16,7 @@ class CdlHeader {
         if (!IRStreamHeader) {
             throw new Error("IRStreamHeader is required.");
         }
-        this.header = JSON5.parse(IRStreamHeader);
+        this.header = IRStreamHeader;
         if (!this.header || typeof this.header !== "object") {
             throw new Error("Invalid header format.");
         }

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -20,6 +20,9 @@ class CdlLog {
         this.globalVariables = {};
         this.traceEvents = [];
 
+        this.inputs = [];
+        this.outputs = [];
+
         this._processLog(logFile);
 
         // Used to go to the end of the file
@@ -43,15 +46,11 @@ class CdlLog {
                     this.execution.push(currLog);
                     this._saveGlobalVariables(currLog);
                     break;
-                case LINE_TYPE.IR_HEADER:
-                    this.header = new CdlHeader(currLog.value);
+                case LINE_TYPE.JSON:
+                    this._processJsonLog(currLog);
                     break;
                 case LINE_TYPE.EXCEPTION:
                     this.exception = currLog.value;
-                    break;
-                case LINE_TYPE.UNIQUE_ID:
-                    this.execution.push(currLog);
-                    this._addToUniqueIds(currLog, position);
                     break;
                 default:
                     break;
@@ -59,18 +58,19 @@ class CdlLog {
         } while (++position < logFile.length);
     }
 
+
     /**
-     * This function adds the given trace event to the global
-     * collection of trace events.
+     * Process JSON Log
      * @param {Object} currLog
-     * @param {Number} position
      */
-    _addToUniqueIds (currLog, position) {
-        this.traceEvents.push({
-            traceEvent: currLog.traceEvent,
-            uid: currLog.uid,
-            position: position,
-        });
+    _processJsonLog (currLog) {
+        if (currLog.value.type == "adli_header") {
+            this.header = new CdlHeader(currLog.value.header);
+        } else if (currLog.value.type == "adli_output") {
+            this.outputs.push(currLog.value);
+        } else if (currLog.value.type == "adli_input") {
+            this.inputs.push(currLog.value);
+        }
     }
 
 

--- a/src/Services/cdl/CdlLogLine.js
+++ b/src/Services/cdl/CdlLogLine.js
@@ -21,11 +21,8 @@ class CdlLogLine {
             case LINE_TYPE_DELIMITER.EXCEPTION:
                 this._processExeception(log);
                 break;
-            case LINE_TYPE_DELIMITER.IR_HEADER:
-                this._processIRHeader(log);
-                break;
-            case LINE_TYPE_DELIMITER.UNIQUE_ID:
-                this._processUniqueId(log);
+            case LINE_TYPE_DELIMITER.JSON:
+                this._processJSON(log);
                 break;
             default:
                 this.type = LINE_TYPE.EXECUTION;
@@ -58,26 +55,12 @@ class CdlLogLine {
     }
 
     /**
-     * Extract metadata from uniqueid log line.
-     * Unique Id:
-     * "@ start <variable_name>"
-     * "@ end <variable_name>"
+     * Extract JSON object from logged line.
      * @param {String} log
      */
-    _processUniqueId (log) {
-        this.type = LINE_TYPE.UNIQUE_ID;
-        const info = log.split(" ");
-        this.traceEvent = info[1];
-        this.uid = this._parseVariableIfJSON(info[2].trim());
-    }
-
-    /**
-     * Extract metadata from header log line.
-     * @param {String} log
-     */
-    _processIRHeader (log) {
-        this.type = LINE_TYPE.IR_HEADER;
-        this.value = log;
+    _processJSON (log) {
+        this.type = LINE_TYPE.JSON;
+        this.value = this._parseVariableIfJSON(log);
     }
 
     /**


### PR DESCRIPTION
Note: This is a breaking change because the format of the header has changed. Older CDL files (before commit https://github.com/vishalpalaniappan/asp-adli-python/commit/17995407bb4a5ce706f666c6a85797a1aa656d39) will not open with this commit.

----

This PR adds a feature to parse inputs and outputs from the log file. To avoid creating a large number of delimiters, the inputs and outputs are logged as JSON objects along with the header. 

Types of JSON logs are specified in the object:
- "adli_header"
- "adli_input"
- "adli_output"

The execution position and execution id of an Input are logged automatically when a variable is detected to have been ADLI encoded. Outputs execution position and execution id are logged when a variable is declared as an output. 

## Validation Performed

Verified that exceptions, variables and statements work with this CDL file:
[compress.zip](https://github.com/user-attachments/files/19746872/compress.zip)

Verified that inputs and outputs work with this CDL file:
[input-output.zip](https://github.com/user-attachments/files/19746877/input-output.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced log processing to support a new JSON log line type, enabling structured handling of log inputs and outputs.

- **Refactor**
  - Updated internal handling of log line types, replacing previous IR_HEADER and UNIQUE_ID types with a unified JSON type for improved consistency.
  - Simplified header processing by removing automatic JSON parsing in header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->