### PR TITLE
Add functionality to go to execution index given a position in the URL.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,14 +22,22 @@ export function App () {
     const [fileInfo, setFileInfo] = useState(null);
     const [executionIndex, setExecutionIndex] = useState(null);
 
+    const validateIndexParam = (index) => {
+        if (index) {
+            if (isNaN(index)) {
+                console.debug("The provided execution index is not a number.");
+            } else {
+                setExecutionIndex(index);
+            }
+        }
+    };
+
     useEffect(() => {
         const filePathParam = new URLSearchParams(window.location.search).get("filePath");
         const execIndexParam = new URLSearchParams(window.location.search).get("executionIndex");
         if (filePathParam) {
             setFileInfo(filePathParam);
-            if (execIndexParam) {
-                setExecutionIndex(execIndexParam);
-            }
+            validateIndexParam(execIndexParam);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
             setAppMode(APP_STATE.FILE_PROMPT);

--- a/src/App.js
+++ b/src/App.js
@@ -18,9 +18,9 @@ export function App () {
         FILE_VIEW: 1,
     };
 
-    const [appMode, setAppMode] = useState(null);
-    const [fileInfo, setFileInfo] = useState(null);
-    const [executionIndex, setExecutionIndex] = useState(null);
+    const [appMode, setAppMode] = useState();
+    const [fileInfo, setFileInfo] = useState();
+    const [executionIndex, setExecutionIndex] = useState();
 
     const validateIndexParam = (index) => {
         if (index) {

--- a/src/App.js
+++ b/src/App.js
@@ -20,11 +20,16 @@ export function App () {
 
     const [appMode, setAppMode] = useState(null);
     const [fileInfo, setFileInfo] = useState(null);
+    const [executionIndex, setExecutionIndex] = useState(null);
 
     useEffect(() => {
-        const filePath = new URLSearchParams(window.location.search).get("filePath");
-        if (filePath) {
-            setFileInfo(filePath);
+        const filePathParam = new URLSearchParams(window.location.search).get("filePath");
+        const execIndexParam = new URLSearchParams(window.location.search).get("executionIndex");
+        if (filePathParam) {
+            setFileInfo(filePathParam);
+            if (execIndexParam) {
+                setExecutionIndex(execIndexParam);
+            }
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
             setAppMode(APP_STATE.FILE_PROMPT);
@@ -43,7 +48,7 @@ export function App () {
     return (
         <DropFile handleFileDrop={handleFileChange}>
             {(APP_STATE.FILE_VIEW === appMode) &&
-                <CDLProviders fileInfo={fileInfo}>
+                <CDLProviders fileInfo={fileInfo} executionIndex={executionIndex}>
                     <Viewer/>
                 </CDLProviders>
             }

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -15,14 +15,14 @@ import WorkerContext from "./WorkerContext";
 CDLProviders.propTypes = {
     children: PropTypes.object,
     fileInfo: PropTypes.string,
-    executionIndex: PropTypes.oneOf([PropTypes.number, PropTypes.undefined]),
+    executionIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([undefined])]),
 };
 
 /**
  * Provides all contexts consumed by the application.
  * @param {JSX} children
  * @param {String} fileInfo
- * @param {Number|null} executionIndex
+ * @param {Number|undefined} executionIndex
  * @return {JSX}
  */
 function CDLProviders ({children, fileInfo, executionIndex}) {

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -15,14 +15,14 @@ import WorkerContext from "./WorkerContext";
 CDLProviders.propTypes = {
     children: PropTypes.object,
     fileInfo: PropTypes.string,
-    executionIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([undefined])]),
+    executionIndex: PropTypes.number,
 };
 
 /**
  * Provides all contexts consumed by the application.
  * @param {JSX} children
  * @param {String} fileInfo
- * @param {Number|undefined} executionIndex
+ * @param {Number} executionIndex
  * @return {JSX}
  */
 function CDLProviders ({children, fileInfo, executionIndex}) {

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -15,14 +15,14 @@ import WorkerContext from "./WorkerContext";
 CDLProviders.propTypes = {
     children: PropTypes.object,
     fileInfo: PropTypes.string,
-    executionIndex: PropTypes.string,
+    executionIndex: PropTypes.number,
 };
 
 /**
  * Provides all contexts consumed by the application.
  * @param {JSX} children
  * @param {String} fileInfo
- * @param {String} executionIndex
+ * @param {Number} executionIndex
  * @return {JSX}
  */
 function CDLProviders ({children, fileInfo, executionIndex}) {

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -15,14 +15,14 @@ import WorkerContext from "./WorkerContext";
 CDLProviders.propTypes = {
     children: PropTypes.object,
     fileInfo: PropTypes.string,
-    executionIndex: PropTypes.number,
+    executionIndex: PropTypes.oneOf([PropTypes.number, PropTypes.undefined]),
 };
 
 /**
  * Provides all contexts consumed by the application.
  * @param {JSX} children
  * @param {String} fileInfo
- * @param {Number} executionIndex
+ * @param {Number|null} executionIndex
  * @return {JSX}
  */
 function CDLProviders ({children, fileInfo, executionIndex}) {

--- a/src/Providers/CDLProviders.js
+++ b/src/Providers/CDLProviders.js
@@ -4,26 +4,28 @@ import PropTypes from "prop-types";
 
 import CDL_WORKER_PROTOCOL from "../Services/CDL_WORKER_PROTOCOL";
 import ActiveFileContext from "./ActiveFileContext";
+import BreakpointsContext from "./BreakpointsContext";
 import FileTreeContext from "./FileTreeContext";
+import GlobalVariablesContext from "./GlobalVariablesContext";
 import StackContext from "./StackContext";
 import StackPositionContext from "./StackPositionContext";
 import VariablesContext from "./VariablesContext";
-import GlobalVariablesContext from "./GlobalVariablesContext";
 import WorkerContext from "./WorkerContext";
-import BreakpointsContext from "./BreakpointsContext";
 
 CDLProviders.propTypes = {
     children: PropTypes.object,
     fileInfo: PropTypes.string,
+    executionIndex: PropTypes.string,
 };
 
 /**
  * Provides all contexts consumed by the application.
  * @param {JSX} children
- * @param {string} fileInfo
+ * @param {String} fileInfo
+ * @param {String} executionIndex
  * @return {JSX}
  */
-function CDLProviders ({children, fileInfo}) {
+function CDLProviders ({children, fileInfo, executionIndex}) {
     const [isLoading, setIsLoading] = useState(false);
     const [activeFile, setActiveFile] = useState();
     const [stack, setStack] = useState();
@@ -47,7 +49,7 @@ function CDLProviders ({children, fileInfo}) {
     // Get new variable stack if stack position changes and update active file
     useEffect(() => {
         if (cdlWorker?.current && stackPosition !== undefined && stack?.[stackPosition]) {
-            setActiveFile(stack[stackPosition].filePath);   
+            setActiveFile(stack[stackPosition].filePath);
             cdlWorker.current.postMessage({
                 code: CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK,
                 args: {
@@ -56,8 +58,7 @@ function CDLProviders ({children, fileInfo}) {
             });
         } else {
             console.warn("Invalid stack position or stack not initialized");
-        }
-        
+        };
     }, [stackPosition, stack]);
 
     // Resets the state variables before loading new file.
@@ -89,7 +90,8 @@ function CDLProviders ({children, fileInfo}) {
                     code: CDL_WORKER_PROTOCOL.LOAD_FILE,
                     args: {
                         fileInfo: fileInfo,
-                    }
+                        executionIndex: executionIndex,
+                    },
                 });
             } catch (error) {
                 console.error("Failed to initialize worker:", error);

--- a/src/Services/cdl/Debugger.js
+++ b/src/Services/cdl/Debugger.js
@@ -12,13 +12,20 @@ class Debugger {
     /**
      * Loads the CDL file and initializes the debugger state.
      * @param {File|String} cdlFile File object or URL of CDL log file.
+     * @param {Number} executionIndex
      */
-    constructor (cdlFile) {
+    constructor (cdlFile, executionIndex) {
+        self.executionIndex = executionIndex;
         readFile(cdlFile).then(async (data) => {
             const module = await clpFfiJsModuleInit();
             const streamReader = new module.ClpStreamReader(data, {});
             const log = streamReader.decodeRange(0, streamReader.deserializeStream(), false);
             this.parseLogAndInitializeDebugger(log);
+            if (executionIndex) {
+                this.cdl.getPositionData(self.executionIndex);
+            } else {
+                this.replayProgram();
+            }
         });
     }
 
@@ -36,7 +43,6 @@ class Debugger {
                 fileTree: this.cdl.header.getSourceFiles(),
             },
         });
-        this.replayProgram();
     }
 
     /**

--- a/src/Services/cdl/Debugger.js
+++ b/src/Services/cdl/Debugger.js
@@ -15,7 +15,6 @@ class Debugger {
      * @param {Number} executionIndex
      */
     constructor (cdlFile, executionIndex) {
-        self.executionIndex = executionIndex;
         readFile(cdlFile).then(async (data) => {
             const module = await clpFfiJsModuleInit();
             const streamReader = new module.ClpStreamReader(data, {});

--- a/src/Services/cdl/Debugger.js
+++ b/src/Services/cdl/Debugger.js
@@ -21,8 +21,15 @@ class Debugger {
             const streamReader = new module.ClpStreamReader(data, {});
             const log = streamReader.decodeRange(0, streamReader.deserializeStream(), false);
             this.parseLogAndInitializeDebugger(log);
+
             if (executionIndex) {
-                this.cdl.getPositionData(self.executionIndex);
+                if (executionIndex < 0 || executionIndex >= this.cdl.execution.length) {
+                    console.debug("The provided execution index is out of bounds.");
+                    console.debug("Going to end of the program.");
+                    this.replayProgram();
+                } else {
+                    this.cdl.getPositionData(executionIndex);
+                }
             } else {
                 this.replayProgram();
             }

--- a/src/Services/cdlWorker.js
+++ b/src/Services/cdlWorker.js
@@ -8,7 +8,7 @@ onmessage = function (e) {
         const args = (e?.data?.args)?e.data.args:{};
         switch (e.data.code) {
             case CDL_WORKER_PROTOCOL.LOAD_FILE:
-                debuggerInstance = new Debugger(args.fileInfo);
+                debuggerInstance = new Debugger(args.fileInfo, args.executionIndex);
                 break;
 
             case CDL_WORKER_PROTOCOL.GET_VARIABLE_STACK:


### PR DESCRIPTION
This PR adds functionality to go to a given executionIndex in the log file by specifying the value in the URL. 

Example:
http://localhost:3011/?filePath=sample.clp.zst&executionIndex=999

In this case, the program would go to index 999 in its execution sequence. If the index corresponds to a variable or exception log statement, it will go the last executed statement before the given position. 

Note: The execution sequence includes the statements, variable values and exceptions. I debated for a while about whether I wanted to limit the index to just the executed statements. If I did that, 999 would correspond to the 999th statement that was logged.

However, I decided to go with the whole execution sequence instead. I can see use cases where a user would want to link to an exception. This might change as I explore more use cases, I might give them the option to specify the index from the full execution sequence or the statements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying an execution index via URL parameter to view particular execution states when loading files.

- **Bug Fixes**
	- Enhanced file loading and execution state initialization to handle execution index correctly, improving debugging accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->