### PR TITLE
Add all logs to the execution array.

### DIFF
--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -26,7 +26,8 @@ class CdlLog {
         this._processLog(logFile);
 
         // Used to go to the end of the file
-        this.lastPosition = this.getLastPosition();
+        this.lastStatement = this.getLastStatement();
+        this.firstStatement = this.getFirstStatement();
     }
 
     /**
@@ -267,6 +268,7 @@ class CdlLog {
      * @param {Number} position
      */
     getPositionData (position) {
+        position = (position < this.firstStatement)?this.firstStatement:position;
         do {
             const positionData = this.execution[position];
             if (positionData.type === LINE_TYPE.EXECUTION) {
@@ -280,20 +282,34 @@ class CdlLog {
                 });
                 break;
             }
-        } while (--position > 0);
+        } while (--pos > 0);
     }
 
     /**
-     * Returns the last position with an execution log type
+     * Returns the last logged statement
      * @return {int}
      */
-    getLastPosition () {
+    getLastStatement () {
         let position = this.execution.length - 1;
         do {
             if (this.execution[position].type === LINE_TYPE.EXECUTION) {
                 return position;
             }
         } while (--position >= 0);
+    }
+
+
+    /**
+     * Returns the first logged statement
+     * @return {int}
+     */
+    getFirstStatement () {
+        let position = 0;
+        do {
+            if (this.execution[position].type === LINE_TYPE.EXECUTION) {
+                return position;
+            }
+        } while (++position <= this.execution.length);
     }
 }
 

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -309,7 +309,7 @@ class CdlLog {
             if (this.execution[position].type === LINE_TYPE.EXECUTION) {
                 return position;
             }
-        } while (++position <= this.execution.length);
+        } while (++position < this.execution.length);
     }
 }
 

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -47,9 +47,11 @@ class CdlLog {
                     this._saveGlobalVariables(currLog);
                     break;
                 case LINE_TYPE.JSON:
+                    this.execution.push(currLog);
                     this._processJsonLog(currLog);
                     break;
                 case LINE_TYPE.EXCEPTION:
+                    this.execution.push(currLog);
                     this.exception = currLog.value;
                     break;
                 default:
@@ -267,7 +269,6 @@ class CdlLog {
     getPositionData (position) {
         do {
             const positionData = this.execution[position];
-
             if (positionData.type === LINE_TYPE.EXECUTION) {
                 postMessage({
                     code: CDL_WORKER_PROTOCOL.GET_POSITION_DATA,

--- a/src/Services/cdl/CdlLog.js
+++ b/src/Services/cdl/CdlLog.js
@@ -282,7 +282,7 @@ class CdlLog {
                 });
                 break;
             }
-        } while (--pos > 0);
+        } while (--position > 0);
     }
 
     /**

--- a/src/Services/cdl/Debugger.js
+++ b/src/Services/cdl/Debugger.js
@@ -70,7 +70,7 @@ class Debugger {
      * This function moves to the start of the file.
      */
     goToStart () {
-        this.cdl.getPositionData(0);
+        this.cdl.getPositionData(1);
     }
 
     /**
@@ -193,7 +193,7 @@ class Debugger {
 
             if (position == null) {
                 // Start of file has been reached
-                this.cdl.getPositionData(0);
+                this.cdl.getPositionData(1);
                 return;
             }
 

--- a/src/Services/cdl/Debugger.js
+++ b/src/Services/cdl/Debugger.js
@@ -70,14 +70,14 @@ class Debugger {
      * This function moves to the start of the file.
      */
     goToStart () {
-        this.cdl.getPositionData(1);
+        this.cdl.getPositionData(this.cdl.firstStatement);
     }
 
     /**
      * This function moves to the end of the file.
      */
     goToEnd () {
-        this.cdl.getPositionData(this.cdl.lastPosition);
+        this.cdl.getPositionData(this.cdl.lastStatement);
     }
 
     /**
@@ -169,7 +169,7 @@ class Debugger {
 
             if (position == null) {
                 // End of file has been reached
-                this.cdl.getPositionData(this.cdl.lastPosition);
+                this.cdl.getPositionData(this.cdl.lastStatement);
                 return;
             }
 
@@ -193,7 +193,7 @@ class Debugger {
 
             if (position == null) {
                 // Start of file has been reached
-                this.cdl.getPositionData(1);
+                this.cdl.getPositionData(this.cdl.firstStatement);
                 return;
             }
 


### PR DESCRIPTION
This PR adds all the logs in the CDL file to the execution array. This fixes #45. 

Since the first log in the file is a no longer a statement, the first logged statement position is saved to a variable. This information is used to perform some debugger operations like goToStart, playBackward and some other logic. 

## Validation Performed

- Loaded log with the following url and arguments:
http://localhost:3011/?filePath=e7a39f0b-68eb-496d-82a8-2bdc3bc81226.clp.zst&executionIndex=20
- Loaded log file at given position and verified that it was correct. To verify that it was correct, the log file was opened in the log viewer and the position was inspected. 
- Tested that go to start, go to end and other debugger operations worked as expected.
- Verified that using executionIndex=0 loads first position in the log file
- Verified that using executionIndex=99999 loads the last position in the log file 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved log handling to ensure all relevant log entries, including JSON and exceptions, are correctly displayed in execution history.
	- Adjusted debugger navigation to start from the first meaningful execution statement and end at the last, enhancing playback accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->